### PR TITLE
Fix recursive call in Trojan stability

### DIFF
--- a/src/lagrange_points.rs
+++ b/src/lagrange_points.rs
@@ -497,9 +497,10 @@ impl TrojanObject {
         stability *= self.stability;
 
         // Bonus für Tadpole-Orbits
+        let mass_parameter =
+            secondary_mass.in_kg() / (primary_mass.in_kg() + secondary_mass.in_kg());
         if matches!(
-            self.calculate_libration_dynamics(primary_mass, secondary_mass, &Distance::au(1.0))
-                .oscillation_pattern,
+            self.determine_oscillation_pattern(mass_parameter),
             OscillationPattern::Tadpole { .. }
         ) {
             stability *= 1.1;


### PR DESCRIPTION
## Summary
- avoid recursive call between `calculate_libration_dynamics` and `assess_long_term_stability`

## Testing
- `cargo test --quiet` *(fails: trojan_tests::test_oscillation_patterns, trojan_tests::test_mutual_trojan_system, system_hierarchy::test_hill_sphere_analysis)*

------
https://chatgpt.com/codex/tasks/task_e_684561c8f93c832e9f0650b8423e3848