### PR TITLE
Fixes to units conversion and imports

### DIFF
--- a/src/physics/astrophysics/lagrange_points.rs
+++ b/src/physics/astrophysics/lagrange_points.rs
@@ -1,4 +1,11 @@
 use crate::physics::units::*;
+use crate::physics::constants::MIN_LAGRANGE_MASS_RATIO;
+use crate::stellar_objects::stars::properties::StellarProperties;
+use crate::stellar_objects::trojans_asteroid::dynamics::MutualDynamics;
+use crate::stellar_objects::trojans_asteroid::objects::{
+    MutualTrojanSystem, TrojanObject,
+};
+use rand_chacha::ChaCha8Rng;
 use serde::{Deserialize, Serialize};
 
 /// Lagrange-Punkt System für ein 2-Körper System
@@ -288,7 +295,7 @@ impl LagrangeSystem {
             // Leichte Variation der Position für sekundäre Trojaner
             let mut sec_trojan = self.generate_enhanced_trojan(
                 lagrange_point,
-                Mass::new(sec_mass.value, sec_mass.system),
+                Mass::new(sec_mass.value_in_system_base(), sec_mass.unit_system()),
                 primary_mass,
                 secondary_mass,
                 rng,

--- a/src/physics/units/acceleration.rs
+++ b/src/physics/units/acceleration.rs
@@ -96,6 +96,15 @@ impl Acceleration {
         self.as_au_per_year_squared()
     }
 
+    /// Konvertiert die Beschleunigung in ein anderes Einheitensystem.
+    pub fn to_system(&self, target: UnitSystem) -> Self {
+        if self.system == target {
+            self.clone()
+        } else {
+            self.to_system_base(target)
+        }
+    }
+
     // --- Konvertierungsmethoden (`as_...` geben den reinen f64 Wert zurück) ---
 
     /// Gibt den Wert der Beschleunigung in Meter pro Sekunde-Quadrat zurück.

--- a/src/physics/units/distance.rs
+++ b/src/physics/units/distance.rs
@@ -75,6 +75,19 @@ impl Distance {
         self.as_au()
     }
 
+    /// Konvertiert die Distanz in ein anderes Einheitensystem.
+    /// Wenn das Zielsystem dem aktuellen System entspricht, wird eine
+    /// Kopie des bestehenden Objekts zurückgegeben. Andernfalls erfolgt
+    /// die Umrechnung über die im [`UnitConversion`] Trait implementierten
+    /// Basisfunktionen.
+    pub fn to_system(&self, target: UnitSystem) -> Self {
+        if self.system == target {
+            self.clone()
+        } else {
+            self.to_system_base(target)
+        }
+    }
+
     /// Gibt den Wert der Distanz in Metern zurück.
     pub fn as_meters(&self) -> f64 {
         match self.system {

--- a/src/physics/units/mass.rs
+++ b/src/physics/units/mass.rs
@@ -88,6 +88,17 @@ impl Mass {
         self.as_solar_masses()
     }
 
+    /// Konvertiert die Masse in ein anderes Einheitensystem. Bei identischem
+    /// Zielsystem wird eine Kopie zurückgegeben, ansonsten erfolgt die
+    /// Umrechnung über [`UnitConversion::to_system_base`].
+    pub fn to_system(&self, target: UnitSystem) -> Self {
+        if self.0.system == target {
+            self.clone()
+        } else {
+            self.to_system_base(target)
+        }
+    }
+
     // --- Konvertierungsmethoden ---
 
     /// Gibt den Wert der Masse in Kilogramm zurück.

--- a/src/physics/units/time.rs
+++ b/src/physics/units/time.rs
@@ -184,6 +184,18 @@ impl Time {
         self.as_gigayears()
     }
 
+    /// Konvertiert die Zeit in ein anderes Einheitensystem. Wenn das
+    /// Zielsystem bereits dem aktuellen entspricht, wird eine Kopie
+    /// zurückgegeben, andernfalls erfolgt die Umrechnung über
+    /// [`UnitConversion::to_system_base`].
+    pub fn to_system(&self, target: UnitSystem) -> Self {
+        if self.system == target {
+            self.clone()
+        } else {
+            self.to_system_base(target)
+        }
+    }
+
     // --- Konvertierungsmethoden (`as_...` geben den reinen f64 Wert zurück) ---
 
     /// Gibt den Wert der Zeit in Sekunden zurück.

--- a/src/physics/units/velocity.rs
+++ b/src/physics/units/velocity.rs
@@ -101,6 +101,15 @@ impl Velocity {
         self.as_au_per_year()
     }
 
+    /// Konvertiert die Geschwindigkeit in ein anderes Einheitensystem.
+    pub fn to_system(&self, target: UnitSystem) -> Self {
+        if self.0.system == target {
+            self.clone()
+        } else {
+            self.to_system_base(target)
+        }
+    }
+
     // --- Konvertierungsmethoden (`as_...` geben den reinen f64 Wert zurück) ---
 
     /// Gibt den Wert der Geschwindigkeit in Meter pro Sekunde zurück.

--- a/src/stellar_objects/bodies/properties.rs
+++ b/src/stellar_objects/bodies/properties.rs
@@ -1,4 +1,10 @@
 use serde::{Deserialize, Serialize};
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::physics::constants::{G, PI};
+use crate::physics::units::{Distance, Mass, Time, UnitSystem, Velocity};
+use crate::stellar_objects::planets::properties::PlanetComposition;
 
 /// Vollständige physikalische Eigenschaften eines Planeten
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,7 +41,7 @@ impl PhysicalProperties {
         age: Time,
         rng: &mut ChaCha8Rng,
     ) -> Self {
-        let unit_system = mass.system;
+        let unit_system = mass.unit_system();
 
         // Radius aus Masse-Radius-Beziehung
         let radius = Self::calculate_radius(&mass, &composition, &age);

--- a/src/stellar_objects/cosmic_environment/dynamic.rs
+++ b/src/stellar_objects/cosmic_environment/dynamic.rs
@@ -1,4 +1,10 @@
 use serde::{Deserialize, Serialize};
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::physics::constants::{KILOPARSEC_IN_METERS, PI};
+use crate::physics::units::{Distance, UnitSystem};
+use crate::stellar_objects::cosmic_environment::region::{GalacticRegion, SpiralArmContext, GasDistribution};
 
 /// Galaktische Dynamik und Struktur
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,9 +43,9 @@ impl GalacticDynamics {
         age_gyr: f64,
         rng: &mut ChaCha8Rng,
     ) -> Self {
-        let distance_kpc = match region.distance_from_center().system {
-            UnitSystem::Astronomical => region.distance_from_center().value,
-            UnitSystem::SI => region.distance_from_center().in_meters() / KILOPARSEC_TO_METERS,
+        let distance_kpc = match region.get_distance_from_center().system {
+            UnitSystem::Astronomical => region.get_distance_from_center().value,
+            UnitSystem::SI => region.get_distance_from_center().in_meters() / KILOPARSEC_IN_METERS,
         };
 
         // Rotationskurve der Milchstraße (vereinfacht)
@@ -52,7 +58,7 @@ impl GalacticDynamics {
         };
 
         // Umlaufperiode
-        let orbital_period = 2.0 * PI * distance_kpc * KILOPARSEC_TO_METERS
+        let orbital_period = 2.0 * PI * distance_kpc * KILOPARSEC_IN_METERS
             / (rotation_velocity * 1000.0)
             / (1e6 * 365.25 * 24.0 * 3600.0); // Myr
 

--- a/src/stellar_objects/cosmic_environment/region.rs
+++ b/src/stellar_objects/cosmic_environment/region.rs
@@ -1,4 +1,9 @@
 use serde::{Deserialize, Serialize};
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::physics::constants::KILOPARSEC_IN_METERS;
+use crate::physics::units::{Distance, UnitSystem};
 
 /// Galaktische Regionen und ihre Eigenschaften
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,7 +104,7 @@ impl GalacticRegion {
 
         let distance = match unit_system {
             UnitSystem::Astronomical => Distance::new(distance_kpc, unit_system),
-            UnitSystem::SI => Distance::meters(distance_kpc * KILOPARSEC_TO_METERS),
+            UnitSystem::SI => Distance::meters(distance_kpc * KILOPARSEC_IN_METERS),
         };
 
         match distance_kpc {
@@ -198,7 +203,7 @@ impl CosmicRadiationEnvironment {
         let age_factor = if epoch.age_universe < 4.0 { 2.0 } else { 1.0 };
         let distance_kpc = match region.distance_from_center().system {
             UnitSystem::Astronomical => region.distance_from_center().value,
-            UnitSystem::SI => region.distance_from_center().in_meters() / KILOPARSEC_TO_METERS,
+            UnitSystem::SI => region.distance_from_center().in_meters() / KILOPARSEC_IN_METERS,
         };
 
         let (base_agn, base_sn, base_grb) = match region {


### PR DESCRIPTION
## Summary
- add basic `to_system` conversion helpers for unit types
- fix imports and constants in astrophysics and cosmic environment modules
- correct unit system access in `PhysicalProperties`

## Testing
- `cargo check` *(fails: could not compile `star_sim`)*

------
https://chatgpt.com/codex/tasks/task_e_6845757fd090832eadedaca618e834d6