### PR TITLE
Add builder implementations

### DIFF
--- a/src/stellar_objects/bodies/builder.rs
+++ b/src/stellar_objects/bodies/builder.rs
@@ -1,0 +1,59 @@
+use super::properties::PhysicalProperties;
+use crate::stellar_objects::planets::properties::PlanetComposition;
+use crate::physics::units::{Mass, Time};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Builder zur Erzeugung von [`PhysicalProperties`]
+pub struct PhysicalPropertiesBuilder {
+    seed: u64,
+    mass: Option<Mass>,
+    composition: Option<PlanetComposition>,
+    age: Option<Time>,
+}
+
+impl PhysicalPropertiesBuilder {
+    /// Neuer Builder mit Standardwerten
+    pub fn new() -> Self {
+        Self {
+            seed: 0,
+            mass: None,
+            composition: None,
+            age: None,
+        }
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn with_mass(mut self, mass: Mass) -> Self {
+        self.mass = Some(mass);
+        self
+    }
+
+    pub fn with_composition(mut self, comp: PlanetComposition) -> Self {
+        self.composition = Some(comp);
+        self
+    }
+
+    pub fn with_age(mut self, age: Time) -> Self {
+        self.age = Some(age);
+        self
+    }
+
+    /// Baut die [`PhysicalProperties`]
+    pub fn build(self) -> PhysicalProperties {
+        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let mass = self
+            .mass
+            .unwrap_or_else(|| Mass::earth_masses(rng.gen_range(0.1..10.0)));
+        let comp = self.composition.unwrap_or_else(|| PlanetComposition::Terrestrial { rock_fraction: 0.7 });
+        let age = self
+            .age
+            .unwrap_or_else(|| Time::years(rng.gen_range(1.0e6..4.5e9)));
+        PhysicalProperties::from_mass_and_composition(mass, comp, age, &mut rng)
+    }
+}
+

--- a/src/stellar_objects/cosmic_environment/builder.rs
+++ b/src/stellar_objects/cosmic_environment/builder.rs
@@ -1,0 +1,81 @@
+use super::dynamic::GalacticDynamics;
+use super::elemental_abundance::ElementalAbundance;
+use super::epoch::CosmicEpoch;
+use super::region::{CosmicRadiationEnvironment, GalacticRegion};
+use crate::physics::units::{UnitSystem, Distance};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Komplettes kosmisches Umfeld mit Epoche und galaktischer Position
+#[derive(Debug, Clone)]
+pub struct CosmicEnvironment {
+    pub epoch: CosmicEpoch,
+    pub region: GalacticRegion,
+    pub dynamics: GalacticDynamics,
+    pub radiation: CosmicRadiationEnvironment,
+    pub elements: ElementalAbundance,
+    pub seed: u64,
+}
+
+/// Builder für [`CosmicEnvironment`]
+pub struct CosmicEnvironmentBuilder {
+    seed: u64,
+    epoch: Option<CosmicEpoch>,
+    region: Option<GalacticRegion>,
+    unit_system: UnitSystem,
+}
+
+impl CosmicEnvironmentBuilder {
+    /// Erstellt einen neuen Builder
+    pub fn new() -> Self {
+        Self {
+            seed: 0,
+            epoch: None,
+            region: None,
+            unit_system: UnitSystem::Astronomical,
+        }
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn with_epoch(mut self, epoch: CosmicEpoch) -> Self {
+        self.epoch = Some(epoch);
+        self
+    }
+
+    pub fn with_region(mut self, region: GalacticRegion) -> Self {
+        self.region = Some(region);
+        self
+    }
+
+    pub fn with_unit_system(mut self, unit_system: UnitSystem) -> Self {
+        self.unit_system = unit_system;
+        self
+    }
+
+    /// Baut das kosmische Umfeld zusammen
+    pub fn build(self) -> CosmicEnvironment {
+        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let epoch = self
+            .epoch
+            .unwrap_or_else(|| CosmicEpoch::from_age(rng.gen_range(3.0..13.8)));
+        let region = self
+            .region
+            .unwrap_or_else(|| GalacticRegion::generate_random(&mut rng, self.unit_system));
+        let dynamics = GalacticDynamics::calculate_for_position(&region, epoch.age_universe, &mut rng);
+        let radiation = CosmicRadiationEnvironment::from_region_and_epoch(&region, &epoch, &mut rng);
+        let elements = ElementalAbundance::from_epoch(&epoch);
+        CosmicEnvironment {
+            epoch,
+            region,
+            dynamics,
+            radiation,
+            elements,
+            seed: self.seed,
+        }
+    }
+}
+

--- a/src/stellar_objects/moons/builder.rs
+++ b/src/stellar_objects/moons/builder.rs
@@ -1,0 +1,59 @@
+use crate::physics::units::{Distance, Mass};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Einfache Mondstruktur
+#[derive(Debug, Clone)]
+pub struct Moon {
+    pub mass: Mass,
+    pub semi_major_axis: Distance,
+    pub seed: u64,
+}
+
+/// Builder für [`Moon`]
+pub struct MoonBuilder {
+    seed: u64,
+    mass: Option<Mass>,
+    semi_major_axis: Option<Distance>,
+}
+
+impl MoonBuilder {
+    pub fn new() -> Self {
+        Self {
+            seed: 0,
+            mass: None,
+            semi_major_axis: None,
+        }
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn with_mass(mut self, mass: Mass) -> Self {
+        self.mass = Some(mass);
+        self
+    }
+
+    pub fn with_semi_major_axis(mut self, axis: Distance) -> Self {
+        self.semi_major_axis = Some(axis);
+        self
+    }
+
+    pub fn build(self) -> Moon {
+        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let mass = self
+            .mass
+            .unwrap_or_else(|| Mass::earth_masses(rng.gen_range(0.001..0.1)));
+        let axis = self
+            .semi_major_axis
+            .unwrap_or_else(|| Distance::earth_radii(rng.gen_range(30.0..1000.0)));
+        Moon {
+            mass,
+            semi_major_axis: axis,
+            seed: self.seed,
+        }
+    }
+}
+

--- a/src/stellar_objects/planets/builder.rs
+++ b/src/stellar_objects/planets/builder.rs
@@ -1,0 +1,52 @@
+use super::properties::PlanetComposition;
+use crate::stellar_objects::bodies::builder::{PhysicalPropertiesBuilder};
+use crate::stellar_objects::bodies::properties::PhysicalProperties;
+use crate::physics::units::{Mass, Time};
+
+/// Einfacher Planet mit physikalischen Eigenschaften
+#[derive(Debug, Clone)]
+pub struct Planet {
+    pub properties: PhysicalProperties,
+}
+
+/// Builder zur Erstellung eines [`Planet`]
+pub struct PlanetBuilder {
+    inner: PhysicalPropertiesBuilder,
+}
+
+impl PlanetBuilder {
+    /// Neuer Builder
+    pub fn new() -> Self {
+        Self {
+            inner: PhysicalPropertiesBuilder::new(),
+        }
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.inner = self.inner.with_seed(seed);
+        self
+    }
+
+    pub fn with_mass(mut self, mass: Mass) -> Self {
+        self.inner = self.inner.with_mass(mass);
+        self
+    }
+
+    pub fn with_composition(mut self, comp: PlanetComposition) -> Self {
+        self.inner = self.inner.with_composition(comp);
+        self
+    }
+
+    pub fn with_age(mut self, age: Time) -> Self {
+        self.inner = self.inner.with_age(age);
+        self
+    }
+
+    /// Baut den Planet
+    pub fn build(self) -> Planet {
+        Planet {
+            properties: self.inner.build(),
+        }
+    }
+}
+

--- a/src/stellar_objects/stars/builder.rs
+++ b/src/stellar_objects/stars/builder.rs
@@ -1,0 +1,56 @@
+use super::properties::StellarProperties;
+use crate::physics::units::{Mass, Time};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Builder für [`StellarProperties`]
+pub struct StellarBuilder {
+    seed: u64,
+    mass: Option<Mass>,
+    age: Option<Time>,
+    metallicity: Option<f64>,
+}
+
+impl StellarBuilder {
+    pub fn new() -> Self {
+        Self {
+            seed: 0,
+            mass: None,
+            age: None,
+            metallicity: None,
+        }
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn with_mass(mut self, mass: Mass) -> Self {
+        self.mass = Some(mass);
+        self
+    }
+
+    pub fn with_age(mut self, age: Time) -> Self {
+        self.age = Some(age);
+        self
+    }
+
+    pub fn with_metallicity(mut self, z: f64) -> Self {
+        self.metallicity = Some(z);
+        self
+    }
+
+    pub fn build(self) -> StellarProperties {
+        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let mass = self
+            .mass
+            .unwrap_or_else(|| Mass::solar_masses(rng.gen_range(0.1..5.0)));
+        let age = self
+            .age
+            .unwrap_or_else(|| Time::years(rng.gen_range(1e6..1e10)));
+        let metallicity = self.metallicity.unwrap_or_else(|| rng.gen_range(-1.0..0.5));
+        StellarProperties::new(mass, age, metallicity)
+    }
+}
+

--- a/src/stellar_objects/stellar_systems/builder.rs
+++ b/src/stellar_objects/stellar_systems/builder.rs
@@ -1,1 +1,32 @@
+use super::properties::StarSystem;
+use crate::physics::units::UnitSystem;
+
+/// Einfacher Builder für [`StarSystem`]
+pub struct StarSystemBuilder {
+    seed: u64,
+    unit_system: UnitSystem,
+}
+
+impl StarSystemBuilder {
+    pub fn new() -> Self {
+        Self {
+            seed: 0,
+            unit_system: UnitSystem::Astronomical,
+        }
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn with_unit_system(mut self, unit_system: UnitSystem) -> Self {
+        self.unit_system = unit_system;
+        self
+    }
+
+    pub fn build(self) -> StarSystem {
+        StarSystem::generate_from_seed_with_units(self.seed, self.unit_system)
+    }
+}
 

--- a/src/stellar_objects/trojans_asteroid/builder.rs
+++ b/src/stellar_objects/trojans_asteroid/builder.rs
@@ -1,0 +1,72 @@
+use super::objects::TrojanObject;
+use crate::physics::units::{Distance, Mass, Time};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Builder für [`TrojanObject`]
+pub struct TrojanBuilder {
+    seed: u64,
+    mass: Option<Mass>,
+    lagrange_point: Option<u8>,
+    amplitude: Option<Distance>,
+    period: Option<Time>,
+}
+
+impl TrojanBuilder {
+    pub fn new() -> Self {
+        Self {
+            seed: 0,
+            mass: None,
+            lagrange_point: None,
+            amplitude: None,
+            period: None,
+        }
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn with_mass(mut self, mass: Mass) -> Self {
+        self.mass = Some(mass);
+        self
+    }
+
+    pub fn with_lagrange_point(mut self, point: u8) -> Self {
+        self.lagrange_point = Some(point);
+        self
+    }
+
+    pub fn with_amplitude(mut self, amp: Distance) -> Self {
+        self.amplitude = Some(amp);
+        self
+    }
+
+    pub fn with_period(mut self, period: Time) -> Self {
+        self.period = Some(period);
+        self
+    }
+
+    pub fn build(self) -> TrojanObject {
+        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let mass = self
+            .mass
+            .unwrap_or_else(|| Mass::earth_masses(rng.gen_range(0.0001..0.01)));
+        let lagrange_point = self.lagrange_point.unwrap_or(if rng.gen_bool(0.5) { 4 } else { 5 });
+        let amplitude = self
+            .amplitude
+            .unwrap_or_else(|| Distance::au(rng.gen_range(0.001..0.1)));
+        let period = self
+            .period
+            .unwrap_or_else(|| Time::years(rng.gen_range(1e0..1e3)));
+        TrojanObject {
+            mass,
+            lagrange_point,
+            oscillation_amplitude: amplitude,
+            oscillation_period: period,
+            stability: rng.gen_range(0.5..1.0),
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement builder structs for many objects
- Cosmic environment builder constructs radiation and dynamics context
- body builder builds physical properties
- planet, moon, star, trojan, and star system now have builders

## Testing
- `cargo check -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d1ec6d94832eb274329abc196549